### PR TITLE
Fixing Planet Manager Error

### DIFF
--- a/Assets/Scenes/Main scene.unity
+++ b/Assets/Scenes/Main scene.unity
@@ -1371,7 +1371,7 @@ GameObject:
   - component: {fileID: 1152961536}
   - component: {fileID: 1152961537}
   m_Layer: 0
-  m_Name: PlanetManager
+  m_Name: SpacePlanetManager
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0

--- a/Assets/Scripts/Managers/PauseMenuManager.cs
+++ b/Assets/Scripts/Managers/PauseMenuManager.cs
@@ -10,7 +10,7 @@ public class PauseMenuManager : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-        pauseMenu = GameObject.Find("Pause Menu");
+        pauseMenu = GameObject.Find("Pause Menu"); 
     }
 
     public void Continue()

--- a/Assets/Scripts/Planets/PlanetDetection.cs
+++ b/Assets/Scripts/Planets/PlanetDetection.cs
@@ -120,7 +120,7 @@ public class PlanetDetection : MonoBehaviour
         {
             o.GetComponent<FindingPlanets>().planetsNotRescued.Remove(gameObject);
         }
-        GameObject a = GameObject.Find("PlanetManager");
+        GameObject a = GameObject.Find("SpacePlanetManager");
         if (a != null)
         {
             int i = a.GetComponent<PlanetSpawn>().planets.IndexOf(gameObject);

--- a/Assets/Scripts/Planets/PlanetTextureGenerator.cs
+++ b/Assets/Scripts/Planets/PlanetTextureGenerator.cs
@@ -21,7 +21,7 @@ public class PlanetTextureGenerator : MonoBehaviour
             r = Random.Range(0,GameSettings.planetPrefabs.Length);
         }   while(GameSettings.planetPrefabs[r] == null);
 
-        int index = GameObject.Find("PlanetManager").GetComponent<PlanetSpawn>().planets.IndexOf(gameObject);
+        int index = GameObject.Find("SpacePlanetManager").GetComponent<PlanetSpawn>().planets.IndexOf(gameObject);
         GameObject[] planetUIobjects = GameObject.FindGameObjectsWithTag("PlanetUI");
         GameObject p = Instantiate(GameSettings.planetPrefabs[r],new Vector3(0,0,0),Quaternion.identity);
         p.transform.SetParent(gameObject.transform);


### PR DESCRIPTION
## Describe your changes

This will fix the null exception errors when going to the main menu from the planet. to fix this I renamed the planetmanager gameobject in the main scene and the referenced scripts. 

## Issue number 

#152 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] This complies with the [product coding guidelines](https://github.com/BIT-Studio-3/Space-Rescue/wiki/Code-Review-Format)
