### PR TITLE
CI Reducing Build Time

### DIFF
--- a/.github/workflows/ci-build-and-release.yml
+++ b/.github/workflows/ci-build-and-release.yml
@@ -32,9 +32,10 @@ jobs:
               uses: actions/cache@v3
               with:
                 path: Library
-                key: Library-${{ hashFiles('Assets/**', 'Packages/**', 'ProjectSettings/**') }}
+                key: Library-Space-Rescue-StandaloneWindows
                 restore-keys: |
-                  Library-
+                    Library-Space-Rescue-
+                    Library-
       
             # Build
             - name: Build Project #Builds the unity Project

--- a/.github/workflows/ci-schedule-cache.yml
+++ b/.github/workflows/ci-schedule-cache.yml
@@ -1,0 +1,38 @@
+name: Cache the Library Files
+on:
+  schedule:
+    - cron: "0 18 * * 3"
+  workflow_dispatch:
+
+jobs:
+  cache-and-build:
+    runs-on: ubuntu-latest
+    name: Cache Library Files
+    steps:
+      # Checkout
+      - name: Checkout Repo #Checkouts to the Repository
+        uses: actions/checkout@v3
+        with:
+          lfs: true # Whether to download Git-LFS files 
+
+      # Cache 
+      - name: Cache Files #Cache un-needed files, significantly reduces build time
+        uses: actions/cache@v3
+        with:
+          path: Library
+          key: Library-Space-Rescue-StandaloneWindows
+          restore-keys: |
+              Library-Space-Rescue-
+              Library-
+        # Build
+      - name: Build Project #Builds the unity Project
+        uses: game-ci/unity-builder@v2
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }} #Explained in Wiki, required for validation and to build the project
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+        with:
+          targetPlatform: StandaloneWindows
+          allowDirtyBuild: true #Allows the build to modify the repo, I had to enable this for the workflow to run
+          buildName: SpaceRescue
+        


### PR DESCRIPTION
This key will be the same every release and significantly reduces the amount of time that the build and release job takes

## Describe your changes

This is going to significantly reduce the amount of time the building takes when merging into main. It changes the restore key to a specific name rather than creating a random hash which causes it to be unable to find it.

## Issue number and link

#188 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] This complies with the [product coding guidelines](https://github.com/BIT-Studio-3/Space-Rescue/wiki/Code-Review-Format)
